### PR TITLE
fix: improve git fetch functionality for branches

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn git_main_branch() -> Result<String, Box<dyn std::error::Error>> {
 
     Ok(String::from_utf8(main_branch_output.stdout)?
         .trim()
+        .trim_start_matches("origin/")
         .to_string())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (branch_name, commit_title, commit_details) =
             gpt_generate_branch_name_and_commit_description(diff_uncommitted).await?;
 
+        info!(
+            "current branch {} main branch {}",
+            current_branch, main_branch
+        );
         if current_branch == main_branch {
             // Create a new branch
             Command::new("git")

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ async fn gpt_generate_branch_name_and_commit_description(
         ChatCompletionMessage {
             role: ChatCompletionMessageRole::System,
             content: Some(
-                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. If the context has only one line, return 'commit_details' as null. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
+                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely describe all changes in the PR and the impact of the changes. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
             ),
             ..Default::default()
         },


### PR DESCRIPTION
This update modifies the `git_fetch_main` function to accept both the current branch and the main branch as parameters, allowing for more flexible fetching logic. Now, if the current branch matches the main branch, it simply fetches from the origin without specifying the main branch explicitly, which can speed up operations when working with the main branch. Additionally, it trims any 'origin/' prefix from the main branch name, which ensures cleaner output when retrieving the branch name. These changes enhance the overall robustness and efficiency of branch management within the application.