### PR TITLE
refactor: update assistant instructions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (branch_name, commit_title, commit_details) =
             gpt_generate_branch_name_and_commit_description(diff_uncommitted).await?;
 
-        info!(
-            "current branch {} main branch {}",
-            current_branch, main_branch
-        );
         if current_branch == main_branch {
             // Create a new branch
             Command::new("git")
@@ -242,7 +238,7 @@ async fn gpt_generate_branch_name_and_commit_description(
             ..Default::default()
         },
     ];
-    info!("req {:#?}", messages);
+
     let chat_request = ChatCompletion::builder("gpt-4o-mini", messages.clone())
         .credentials(credentials.clone())
         .create()

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,7 @@ async fn gpt_generate_branch_name_and_commit_description(
         ChatCompletionMessage {
             role: ChatCompletionMessageRole::System,
             content: Some(
-                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely describe all changes in the PR and the impact of the changes. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
+                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely in a structured way describe all changes in the PR and the impact of the changes. Do not use empty words or sentences such as 'this enhances'. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
             ),
             ..Default::default()
         },


### PR DESCRIPTION
This commit modifies the assistant's instructions within the `gpt_generate_branch_name_and_commit_description` function in `main.rs`. The previous instruction text regarding the output format was streamlined to specify that 'commit_details' should be null for very small PRs. Additionally, it emphasizes structured descriptions of changes, avoiding vague language. The logging statement that displayed current branch information was removed as it was deemed unnecessary.