### PR TITLE
fix: ensure not in detached HEAD state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ async fn gpt_generate_branch_name_and_commit_description(
         ChatCompletionMessage {
             role: ChatCompletionMessageRole::System,
             content: Some(
-                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely in a well structured markdown format describe all changes in the PR and the impact of the changes. Do not use empty words or sentences such as 'this enhances'. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
+                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely in a well structured markdown format describe all changes in the PR. Also provide the impact of the changes but only if there is clear and significant impact. Do not use empty words or sentences such as 'this enhances'. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
             ),
             ..Default::default()
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ async fn gpt_generate_branch_name_and_commit_description(
         ChatCompletionMessage {
             role: ChatCompletionMessageRole::System,
             content: Some(
-                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely in a structured way describe all changes in the PR and the impact of the changes. Do not use empty words or sentences such as 'this enhances'. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
+                "You are a helpful assistant that helps to prepare GitHub PRs. You will provide output in JSON format with keys: 'branch_name', 'commit_title', and 'commit_details'. For a very small PR return 'commit_details' as null, otherwise humbly and politely in a well structured markdown format describe all changes in the PR and the impact of the changes. Do not use empty words or sentences such as 'this enhances'. Follow the Conventional Commits specification for formatting PR descriptions.".to_string(),
             ),
             ..Default::default()
         },


### PR DESCRIPTION
# Changes

- Added a new function `git_ensure_not_detached_head` to check if the repository is in a detached HEAD state. This function will exit with an error if the user is not on a branch, preventing further operations that may be detrimental in such a state.
- Updated the `main` function to call `git_ensure_not_detached_head` using the current branch name.

# Impact

These changes help to ensure that users are working on a valid branch before proceeding with further Git operations. This prevents confusion and potential data loss caused by unintentional commits in a detached state.