### PR TITLE
refactor: change parameter type of git_push_branch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,9 +216,9 @@ fn git_stage_and_commit(
     Ok(())
 }
 
-fn git_push_branch(branch_name: &String) -> Result<(), std::io::Error> {
+fn git_push_branch(branch_name: &str) -> Result<(), std::io::Error> {
     Command::new("git")
-        .args(["push", "origin", &branch_name])
+        .args(["push", "origin", branch_name])
         .status()?;
     Ok(())
 }


### PR DESCRIPTION
### Changes

- Refactored the `git_push_branch` function to change the parameter type from `&String` to `&str`.
- This change simplifies the way the function accepts the branch name as it allows passing string slices directly.

