### PR TITLE
fix: change git fetch to git pull for current branch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn git_current_branch() -> Result<String, std::io::Error> {
 
 fn git_fetch_main(current_branch: &String, main_branch: &String) -> Result<(), std::io::Error> {
     if current_branch == main_branch {
-        Command::new("git").args(["fetch", "origin"]).status()?;
+        Command::new("git").args(["pull", "origin"]).status()?;
     } else {
         Command::new("git")
             .args([


### PR DESCRIPTION
### Changes

- Updated the `git_fetch_main` function to replace `git fetch origin` with `git pull origin` when the current branch matches the main branch.

### Reasoning

This change ensures that the local branch is updated with the latest changes from the remote branch directly, making it more straightforward for users to keep their branch in sync.