### PR TITLE
feat: support updating existing PRs

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -240,7 +240,16 @@ pub fn create_or_update_pull_request(
         // PR exists, update it
         app.add_log("INFO", "Existing PR found, updating...");
         let update_output = Command::new("gh")
-            .args(["pr", "edit", "--title", title, "--body", body])
+            .args([
+                "pr",
+                "edit",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--assignee",
+                "@me",
+            ])
             .output()?;
 
         if !update_output.status.success() {
@@ -255,7 +264,16 @@ pub fn create_or_update_pull_request(
     } else {
         // Create new PR
         let create_output = Command::new("gh")
-            .args(["pr", "create", "--title", title, "--body", body])
+            .args([
+                "pr",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--assignee",
+                "@me",
+            ])
             .output()?;
 
         if !create_output.status.success() {

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -245,7 +245,10 @@ pub fn create_or_update_pull_request(
         ])
         .output()?;
 
-    if check_output.status.success() {
+    if check_output.status.success()
+        && !String::from_utf8(check_output.stdout)?
+            .starts_with("no pull requests match your search")
+    {
         // PR exists, update it
         app.add_log("INFO", "Existing PR found, updating...");
         let update_output = Command::new("gh")

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -245,12 +245,12 @@ pub fn create_or_update_pull_request(
         ])
         .output()?;
 
+    let s = String::from_utf8(check_output.stdout)?.trim().to_string();
     if check_output.status.success()
-        && !String::from_utf8(check_output.stdout)?
-            .starts_with("no pull requests match your search")
+        && !(s.is_empty() || s.starts_with("no pull requests match your search"))
     {
         // PR exists, update it
-        app.add_log("INFO", "Existing PR found, updating...");
+        app.add_log("INFO", format!("Existing PR found, updating: {}", s));
         let update_output = Command::new("gh")
             .args([
                 "pr",

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -234,7 +234,16 @@ pub fn create_or_update_pull_request(
     body: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // First check if PR already exists
-    let check_output = Command::new("gh").args(["pr", "view"]).output()?;
+    let check_output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--head",
+            &git_current_branch(app)?,
+        ])
+        .output()?;
 
     if check_output.status.success() {
         // PR exists, update it

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,16 +125,15 @@ async fn run<B: Backend>(
             let output = Command::new("git")
                 .args(["checkout", "-b", &branch_name])
                 .output()?;
+            current_branch = branch_name;
             app.add_log("INFO", String::from_utf8_lossy(&output.stdout).to_string());
             if !output.status.success() {
                 app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
             }
             terminal.draw(|f| ui(f, app))?;
-
-            git_stage_and_commit(app, &commit_title, &commit_details)?;
-            current_branch = branch_name;
-            terminal.draw(|f| ui(f, app))?;
         }
+        git_stage_and_commit(app, &commit_title, &commit_details)?;
+        terminal.draw(|f| ui(f, app))?;
     } else if current_branch == main_branch {
         app.add_log("INFO", "No changes to commit.");
         terminal.draw(|f| ui(f, app))?;
@@ -180,7 +179,7 @@ async fn run<B: Backend>(
     app.update_progress(0.8);
     terminal.draw(|f| ui(f, app))?;
 
-    let _ = create_pull_request(app, &commit_title, &commit_details.unwrap_or_default());
+    let _ = create_or_update_pull_request(app, &commit_title, &commit_details.unwrap_or_default());
     terminal.draw(|f| ui(f, app))?;
 
     app.add_log("SUCCESS", "Pull request created successfully.");


### PR DESCRIPTION
### Description

Refactor `create_pull_request` function to `create_or_update_pull_request` to handle updating existing pull requests if one is found for the current branch. This prevents creating multiple PRs for the same set of changes.

### Changes

- **Modified**: `create_pull_request` to `create_or_update_pull_request` in `git_ops.rs`:
  - Check for an existing open PR for the current branch before trying to create a new one using `gh pr list`.
  - If an existing PR is found, update it using `gh pr edit` with the provided title and body.
  - If no existing PR is found, create a new one using `gh pr create` as before.
  
- **Updated**: Function call in `main.rs` to use the new `create_or_update_pull_request` function.
  - Adjusted the order of operations to set the `current_branch` variable before staging and committing changes.

### Notes
- This change abstracts the logic to handle whether to create or update a PR, providing smoother workflow integration.
- Addressed the ordering issue with setting `current_branch` before calling `git_stage_and_commit` to ensure proper branch tracking.

### How to Test
- Trigger creation of PR on a branch with no existing PR and verify it creates a new one.
- Trigger on a branch with an existing PR and verify it updates the existing PR, without creating duplicates.