### PR TITLE
feat: log pull request URL after creation

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -299,5 +299,14 @@ pub fn create_or_update_pull_request(
         app.add_log("SUCCESS", "Pull request created successfully");
     }
 
+    // Get and log the PR URL
+    let url_output = Command::new("gh")
+        .args(["pr", "view", "--json", "url", "--jq", ".url"])
+        .output()?;
+    if url_output.status.success() {
+        if let Ok(url) = String::from_utf8(url_output.stdout) {
+            app.add_log("INFO", format!("Pull request URL: {}", url.trim()));
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
### Description

This update introduces functionality to log the URL of a pull request immediately after it is created. This enhancement primarily leverages the GitHub CLI to retrieve the PR URL and logs it using the existing logging mechanism.

### Changes

- **New Code Block:**
  - Utilizes the `gh` command line tool to view the PR details and fetch the URL using specific JSON formatting.
  - Parses the output to extract and log the URL if the command executes successfully.
  - Integrates the URL logging into the existing flow post PR creation, providing immediate access to the PR link.

### Notes

- The retrieval and logging of the URL are performed only if the `gh` command executes successfully and the URL can be extracted from the command output.