### PR TITLE
fix: include current directory in git diff options

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -92,6 +92,7 @@ pub fn git_diff_between_branches(
             "diff",
             &format!("{}...{}", main_branch, current_branch),
             "--",
+            ".",
             ":!*.lock",
         ])
         .output()?;


### PR DESCRIPTION
The command used to compute differences between branches has been modified to include the current directory in its search scope by adding a '.' argument. This adjustment ensures that the git diff command operates on the correct path and potentially improves the accuracy of changes detected. The exclusion of lock files remains intact with ':!*.lock'.
