### PR TITLE
fix(tui): adjust layout and add help text

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -106,7 +106,7 @@ pub fn ui(f: &mut ratatui::Frame, app: &mut App) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
-            Constraint::Length(3),
+            Constraint::Length(1),
             Constraint::Min(0),
             Constraint::Length(3),
         ])
@@ -134,6 +134,9 @@ pub fn ui(f: &mut ratatui::Frame, app: &mut App) {
             .add_modifier(Modifier::BOLD),
     );
     f.render_widget(tabs, chunks[0]);
+
+    let help = Paragraph::new("Press 'q' to quit").style(Style::default().fg(Color::Gray));
+    f.render_widget(help, chunks[1]);
 
     app.update_blink();
 


### PR DESCRIPTION
### Changes Made

- **Layout Adjustment:**
  - Modified the length constraint in the Vertical direction from `3` to `1` for better spacing in the UI.

- **Help Text Addition:**
  - Added a help text widget to the UI that displays a message to the user: 'Press 'q' to quit', styled with a gray foreground color.

These changes improve the overall user interface by adjusting layout spacing and providing basic interaction guidance.