### PR TITLE
feat(cli): add --ready flag for PR readiness

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -403,6 +403,7 @@ pub fn create_or_update_pull_request(
     title: &str,
     body: &str,
     update_pr: bool,
+    ready: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let should_update = if update_pr {
         // Check if PR exists
@@ -460,19 +461,21 @@ pub fn create_or_update_pull_request(
         return Err("No existing PR found to update".into());
     } else {
         // Create new PR
-        let create_output = Command::new("gh")
-            .args([
-                "pr",
-                "create",
-                "--draft",
-                "--title",
-                title,
-                "--body",
-                body,
-                "--assignee",
-                "@me",
-            ])
-            .output()?;
+        let mut args = vec![
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+            "--assignee",
+            "@me",
+        ];
+        if !ready {
+            args.push("--draft");
+        }
+
+        let create_output = Command::new("gh").args(&args).output()?;
 
         if !create_output.status.success() {
             app.add_error(String::from_utf8_lossy(&create_output.stderr).to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,10 @@ struct Args {
     /// Update an existing PR instead of creating a new one
     #[arg(long)]
     update: bool,
+
+    /// Create PR as ready for review instead of draft
+    #[arg(long)]
+    ready: bool,
 }
 use ratatui::{
     backend::{Backend, CrosstermBackend},
@@ -40,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut app = App::new("GitHub PR Auto-Submit");
     let tick_rate = Duration::from_millis(250);
-    let app_result = run(&mut terminal, &mut app, tick_rate, args.update).await;
+    let app_result = run(&mut terminal, &mut app, tick_rate, args.update, args.ready).await;
 
     // restore terminal
     disable_raw_mode()?;
@@ -67,6 +71,7 @@ async fn run<B: Backend>(
     app: &mut App<'_>,
     tick_rate: Duration,
     update_pr: bool,
+    ready: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut last_tick = Instant::now();
 
@@ -247,6 +252,7 @@ async fn run<B: Backend>(
         &commit_title,
         &commit_details.unwrap_or_default(),
         update_pr,
+        ready,
     ) {
         Ok(_) => {
             app.add_log("INFO", "Pull request created/updated successfully.");


### PR DESCRIPTION
- introduce `--ready` CLI option to create pull requests as ready for review
- propagate `ready` flag through `run` to `create_or_update_pull_request`
- conditionally omit `--draft` when creating PR if `ready` is true