### PR TITLE
feat: integrate GitHub issues into AI prompt

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -499,3 +499,36 @@ pub fn create_or_update_pull_request(
     }
     Ok(())
 }
+
+// Example GitHub issues JSON output:
+/*
+[
+  {
+    "body": "This is a body of the GH issue.",
+    "labels": [
+      {
+        "id": "LA_kwDOOTdaS88AAAAB9JPIwX",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 42,
+    "title": "This is a title of the GH issue."
+  }
+]
+*/
+pub fn git_list_issues(app: &mut App) -> Result<String, Box<dyn std::error::Error>> {
+    let output = Command::new("gh")
+        .args(["issue", "list", "--json", "number,title,labels,body"])
+        .output()?;
+
+    if !output.status.success() {
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to list issues".into());
+    }
+
+    let json_str = String::from_utf8(output.stdout)?;
+    app.add_log("INFO", "Successfully retrieved GitHub issues");
+    Ok(json_str)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,11 +164,21 @@ async fn run<B: Backend>(
         app.update_details(diff_uncommitted.clone());
         terminal.draw(|f| ui(f, app))?;
 
+        app.add_log("INFO", "Fetching GitHub issues...");
+        terminal.draw(|f| ui(f, app))?;
+
+        let issues_json = git_list_issues(app)?;
+
         app.add_log("INFO", "Generating branch name and commit description...");
         terminal.draw(|f| ui(f, app))?;
 
         let (branch_name, commit_title, commit_details) =
-            gpt_generate_branch_name_and_commit_description(app, diff_uncommitted).await?;
+            gpt_generate_branch_name_and_commit_description(
+                app,
+                diff_uncommitted,
+                Some(issues_json),
+            )
+            .await?;
         terminal.draw(|f| ui(f, app))?;
 
         if update_pr {
@@ -223,8 +233,17 @@ async fn run<B: Backend>(
     app.update_progress(0.5);
     terminal.draw(|f| ui(f, app))?;
 
-    let (_, commit_title, commit_details) =
-        gpt_generate_branch_name_and_commit_description(app, diff_between_branches).await?;
+    app.add_log("INFO", "Fetching GitHub issues...");
+    terminal.draw(|f| ui(f, app))?;
+
+    let issues_json = git_list_issues(app)?;
+
+    let (_, commit_title, commit_details) = gpt_generate_branch_name_and_commit_description(
+        app,
+        diff_between_branches,
+        Some(issues_json),
+    )
+    .await?;
     app.add_log("INFO", format!("Commit title: {commit_title}"));
     app.add_log(
         "INFO",


### PR DESCRIPTION
- add `git_list_issues` to fetch open issues via `gh issue list`
- cap issues JSON to 16K chars to avoid prompt overflow
- extend `gpt_generate_branch_name_and_commit_description` to accept and embed issues context
- update `main.rs` to retrieve issues before each branch/commit generation
- update prompt template to instruct AI to reference and close relevant issues