### PR TITLE
feat: truncate git diffs, discover parent branch, and refine checkout logic

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -542,23 +542,9 @@ pub fn git_checkout_new_branch(
     }
 
     // 4. Configure tracking — remote if available, otherwise local
-    let status = if !upstream.is_empty() {
-        // Track the same remote as the source branch.
-        Command::new("git")
-            .args(["branch", "--set-upstream-to", &upstream, branch_name])
-            .status()?
-    } else {
-        // Track the local source branch.
-        Command::new("git")
-            .args(["branch", "--set-upstream-to", current_branch, branch_name])
-            .status()?
-    };
-
-    if !status.success() {
-        let e = "failed to set upstream";
-        app.add_error(e);
-        return Err(e.into());
-    }
+    Command::new("git")
+        .args(["branch", "--set-upstream-to", current_branch, branch_name])
+        .status()?;
 
     app.add_log(
         "INFO",

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,13 +184,13 @@ async fn run<B: Backend>(
         if update_pr {
             if current_branch == main_branch {
                 // When updating a PR on the main branch, create a new branch
-                git_checkout_new_branch(app, &branch_name, false)?;
+                git_checkout_new_branch(app, &branch_name, &current_branch, false)?;
                 current_branch = branch_name;
                 terminal.draw(|f| ui(f, app))?;
             }
         } else {
             // When not updating, always create a new branch
-            git_checkout_new_branch(app, &branch_name, false)?;
+            git_checkout_new_branch(app, &branch_name, &current_branch, false)?;
             app.add_log("INFO", format!("Created new branch: {branch_name}"));
             current_branch = branch_name;
             terminal.draw(|f| ui(f, app))?;


### PR DESCRIPTION
### Major changes

- git_diff_uncommitted: limit output to 200 KiB, prefer staged changes over working-tree, and truncate on UTF-8 boundaries via `truncate_utf8`
- Introduce `git_run_diff` helper to reduce duplication and handle empty diffs
- Add `discover_parent_branch` with heuristics for upstream, nearest ancestor, and helpers (`upstream_of`, `for_each_local_ref`, `commit_distance`)
- Enhance `git_checkout_new_branch` to accept `current_branch`, refuse clobbering without `force_reset`, reset branch tip, and auto-set upstream
- Update CLI flag `--update` to `--update-pr` and adjust main flow to compute `current_branch_merge_base` via `discover_parent_branch`, alter diff handling, and branch creation logic