### PR TITLE
refactor(git_ops): simplify pull request creation/updating

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,8 @@ async fn run<B: Backend>(
         &commit_details.unwrap_or_default(),
         update_pr,
         ready,
+        &current_branch_merge_base,
+        &current_branch,
     ) {
         Ok(_) => {
             app.add_log("INFO", "Pull request created/updated successfully.");


### PR DESCRIPTION
### Changes

- Refactored `create_or_update_pull_request` signature: removed automatic base branch detection and added explicit `base_branch` and `current_branch` parameters.
- Removed parsing of `gh pr list` JSON output and parent branch fallback logic.
- Updated CLI invocation to always include `--head` and `--base` flags when creating PRs; unified argument construction for edits.
- Enhanced logging messages for create/update flows.
- Updated `main.rs` to pass the new parameters to `create_or_update_pull_request`.
