### PR TITLE
refactor(git): use parent_branch parameter and strip origin prefix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ async fn run<B: Backend>(
     let is_current_branch_main = current_branch == main_branch;
     // If on main branch ==> current_branch_merge_base is None
     // If not on main branch ==> current_branch_merge_base is the merge base with main
-    let current_branch_merge_base = discover_parent_branch(app, &current_branch, &main_branch)?;
+    let current_branch_merge_base = discover_parent_branch(app, &main_branch, &current_branch)?;
 
     let original_branch = current_branch.clone();
     terminal.draw(|f| ui(f, app))?;


### PR DESCRIPTION
### Changes

- Rename `main_branch` parameter to `parent_branch` in `git_diff_between_branches` and update fallback logic to use it
- Strip `origin/` prefix when determining parent or upstream branches in both diff and upstream resolution
- Swap parameter order for `discover_parent_branch` and update its invocation in `main.rs`
- Replace `-u` with `--set-upstream` flag in `git_push_branch`