### PR TITLE
feat(git): detect temp worktree and skip manual cleanup

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -1159,6 +1159,16 @@ pub fn git_list_issues(app: &mut App) -> Result<String, Box<dyn Error>> {
 
 static ISSUES_CACHE: OnceCell<Mutex<Option<String>>> = OnceCell::new();
 
+/// Check if we're currently in a temporary worktree
+pub fn is_in_temp_worktree() -> bool {
+    if let Ok(current_dir) = std::env::current_dir() {
+        if let Some(dir_name) = current_dir.file_name().and_then(|n| n.to_str()) {
+            return dir_name.starts_with("autopr-wt-");
+        }
+    }
+    false
+}
+
 /// Clean up old patch files to prevent accumulation
 /// Removes patch files older than `days_old` days
 pub fn cleanup_old_patches(app: &mut App, days_old: u64) -> Result<(), Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,17 +367,24 @@ async fn run<B: Backend>(
     terminal.draw(|f| ui(f, app))?;
     check_events(terminal, app, tick_rate, &mut last_tick)?;
 
-    git_checkout_branch(app, &original_branch)?;
-    terminal.draw(|f| ui(f, app))?;
-    check_events(terminal, app, tick_rate, &mut last_tick)?;
+    // Skip manual cleanup when in temp worktree - TempWorktree::Drop handles it automatically
+    if !is_in_temp_worktree() {
+        git_checkout_branch(app, &original_branch)?;
+        terminal.draw(|f| ui(f, app))?;
+        check_events(terminal, app, tick_rate, &mut last_tick)?;
 
-    git_pull_branch(app, &original_branch)?;
-    terminal.draw(|f| ui(f, app))?;
-    check_events(terminal, app, tick_rate, &mut last_tick)?;
+        git_pull_branch(app, &original_branch)?;
+        terminal.draw(|f| ui(f, app))?;
+        check_events(terminal, app, tick_rate, &mut last_tick)?;
 
-    git_stash_pop_autostash_if_exists(app)?;
-    terminal.draw(|f| ui(f, app))?;
-    check_events(terminal, app, tick_rate, &mut last_tick)?;
+        git_stash_pop_autostash_if_exists(app)?;
+        terminal.draw(|f| ui(f, app))?;
+        check_events(terminal, app, tick_rate, &mut last_tick)?;
+    } else {
+        app.add_log("INFO", "Skipping manual cleanup - temp worktree will handle it automatically");
+        terminal.draw(|f| ui(f, app))?;
+        check_events(terminal, app, tick_rate, &mut last_tick)?;
+    }
 
     // Cancel the UI progress-update task
     ui_update.abort();


### PR DESCRIPTION
### What
- Introduce `is_in_temp_worktree` in `git_ops.rs` to detect temporary worktrees by directory name prefix (`autopr-wt-`).
- In `main.rs`, guard post-run cleanup steps (`git_checkout_branch`, `git_pull_branch`, `git_stash_pop_autostash_if_exists`) behind `!is_in_temp_worktree()`.
- Emit an INFO log when manual cleanup is skipped in a temp worktree.

### Why
- `TempWorktree::Drop` already handles cleanup for ephemeral worktrees.
- Prevent redundant git operations and avoid potential branch conflicts during teardown.

### Bigger Picture
- Enhances support for isolated, ephemeral worktree workflows.
- Lays groundwork for more robust multi-worktree management in future updates.
