### PR TITLE
feat(gpt_ops): validate git branch names

### DIFF
--- a/src/gpt_ops/tests.rs
+++ b/src/gpt_ops/tests.rs
@@ -184,3 +184,56 @@ fn test_conventional_commits_examples() {
     assert!(system_message.starts_with("feat"));
     assert!(system_message.contains(":"));
 }
+
+#[test]
+fn test_valid_git_branch_names() {
+    // Test valid branch names
+    assert!(is_valid_git_branch_name("feature/add-tests"));
+    assert!(is_valid_git_branch_name("fix-memory-leak"));
+    assert!(is_valid_git_branch_name("feat/worktree-update"));
+    assert!(is_valid_git_branch_name("release/v1.0.0"));
+    assert!(is_valid_git_branch_name("hotfix/security-patch"));
+    assert!(is_valid_git_branch_name("main"));
+    assert!(is_valid_git_branch_name("develop"));
+    assert!(is_valid_git_branch_name("feature_branch"));
+    assert!(is_valid_git_branch_name("123-fix-issue"));
+    assert!(is_valid_git_branch_name("user/feature"));
+}
+
+#[test]
+fn test_invalid_git_branch_names() {
+    // Test invalid branch names - these should all return false
+    assert!(!is_valid_git_branch_name("feat(worktree): update"));
+    assert!(!is_valid_git_branch_name("fix memory leak"));
+    assert!(!is_valid_git_branch_name("feature: add validation"));
+    assert!(!is_valid_git_branch_name("branch with spaces"));
+    assert!(!is_valid_git_branch_name(""));
+    assert!(!is_valid_git_branch_name("-"));
+    assert!(!is_valid_git_branch_name(".hidden"));
+    assert!(!is_valid_git_branch_name("branch."));
+    assert!(!is_valid_git_branch_name("branch..name"));
+    assert!(!is_valid_git_branch_name("branch@name"));
+    assert!(!is_valid_git_branch_name("branch#name"));
+    assert!(!is_valid_git_branch_name("branch$name"));
+    assert!(!is_valid_git_branch_name("branch%name"));
+    assert!(!is_valid_git_branch_name("branch^name"));
+    assert!(!is_valid_git_branch_name("branch&name"));
+    assert!(!is_valid_git_branch_name("branch*name"));
+    assert!(!is_valid_git_branch_name("branch(name)"));
+    assert!(!is_valid_git_branch_name("branch[name]"));
+    assert!(!is_valid_git_branch_name("branch{name}"));
+    assert!(!is_valid_git_branch_name("branch|name"));
+    assert!(!is_valid_git_branch_name("branch\\name"));
+    assert!(!is_valid_git_branch_name("branch?name"));
+    assert!(!is_valid_git_branch_name("branch<name>"));
+    assert!(!is_valid_git_branch_name("branch,name"));
+    assert!(!is_valid_git_branch_name("branch;name"));
+    assert!(!is_valid_git_branch_name("branch:name"));
+    assert!(!is_valid_git_branch_name("branch\"name"));
+    assert!(!is_valid_git_branch_name("branch'name"));
+    assert!(!is_valid_git_branch_name("branch~name"));
+    assert!(!is_valid_git_branch_name("branch`name"));
+    assert!(!is_valid_git_branch_name("branch!name"));
+    assert!(!is_valid_git_branch_name("branch+name"));
+    assert!(!is_valid_git_branch_name("branch=name"));
+}


### PR DESCRIPTION
### What
- Introduce `is_valid_git_branch_name` to enforce Git branch naming rules
- Integrate validation in `gpt_generate_branch_name_and_commit_description`, reporting an error when GPT returns an invalid name
- Add comprehensive unit tests for valid and invalid branch name scenarios

### Why
- Prevent downstream errors caused by invalid branch names
- Ensure automated branch naming adheres to Git’s allowed character set and formatting constraints

### Bigger Picture
- Strengthens reliability of GPT-driven workflows by validating outputs early
- Establishes a pattern for adding more GPT output validations in future

TODO: Expand on impact to CI/CD and developer experience