### PR TITLE
refactor(git_ops): simplify error returns for git commands

### DIFF
--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -258,9 +258,8 @@ pub fn git_main_branch(app: &mut App) -> Result<String, Box<dyn Error>> {
             .output()?;
 
         if !output.status.success() {
-            let err = String::from_utf8_lossy(&output.stderr).to_string();
-            app.add_error(err.clone());
-            return Err(format!("Failed to set origin HEAD: {}", err).into());
+            app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+            return Err("Failed to set origin HEAD".into());
         }
 
         main_branch_output = Command::new("git")
@@ -268,9 +267,8 @@ pub fn git_main_branch(app: &mut App) -> Result<String, Box<dyn Error>> {
             .output()?;
 
         if !main_branch_output.status.success() {
-            let err = String::from_utf8_lossy(&main_branch_output.stderr).to_string();
-            app.add_error(err.clone());
-            return Err(format!("Failed to determine main branch: {}", err).into());
+            app.add_error(String::from_utf8_lossy(&main_branch_output.stderr).to_string());
+            return Err("Failed to determine main branch".into());
         }
     }
 
@@ -288,9 +286,8 @@ pub fn git_current_branch(app: &mut App) -> Result<String, Box<dyn Error>> {
         .output()?;
 
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).to_string();
-        app.add_error(err.clone());
-        return Err(format!("Failed to get current branch: {}", err).into());
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to get current branch".into());
     }
 
     let branch = String::from_utf8(output.stdout)?.trim().to_string();
@@ -594,9 +591,8 @@ pub fn git_fetch_main(
             // Pull latest changes
             let output = Command::new("git").args(["pull", "origin"]).output()?;
             if !output.status.success() {
-                let err = String::from_utf8_lossy(&output.stderr).to_string();
-                app.add_error(err.clone());
-                return Err(format!("Failed to pull from origin: {}", err).into());
+                app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+                return Err("Failed to pull from origin".into());
             }
             app.add_log("INFO", "Pulled latest changes from origin");
 
@@ -627,9 +623,8 @@ pub fn git_fetch_main(
         // Only reach here if no staged changes were detected
         let output = Command::new("git").args(["pull", "origin"]).output()?;
         if !output.status.success() {
-            let err = String::from_utf8_lossy(&output.stderr).to_string();
-            app.add_error(err.clone());
-            return Err(format!("Failed to pull from origin: {}", err).into());
+            app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+            return Err("Failed to pull from origin".into());
         }
         app.add_log("INFO", "Pulled latest changes from origin");
     } else {
@@ -641,9 +636,8 @@ pub fn git_fetch_main(
             ])
             .output()?;
         if !output.status.success() {
-            let err = String::from_utf8_lossy(&output.stderr).to_string();
-            app.add_error(err.clone());
-            return Err(format!("Failed to fetch main branch: {}", err).into());
+            app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+            return Err("Failed to fetch main branch".into());
         }
         app.add_log("INFO", format!("Fetched latest {} branch", main_branch));
     }
@@ -657,9 +651,8 @@ pub fn git_checkout_branch(app: &mut App, branch_name: &str) -> Result<String, B
         .output()?;
 
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).to_string();
-        app.add_error(err.clone());
-        return Err(format!("Failed to checkout branch: {}", err).into());
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to checkout branch".into());
     }
 
     app.add_log("INFO", format!("Checked out branch: {}", branch_name));
@@ -720,9 +713,8 @@ pub fn git_commit_staged_changes(
         .args(["commit", "-m", &commit_message])
         .output()?;
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).to_string();
-        app.add_error(err.clone());
-        return Err(format!("Failed to commit changes: {}", err).into());
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to commit changes".into());
     }
     app.add_log("INFO", "Committed changes successfully");
 
@@ -735,9 +727,8 @@ pub fn git_pull_branch(app: &mut App, branch_name: &str) -> Result<(), Box<dyn E
         .output()?;
 
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).to_string();
-        app.add_error(err.clone());
-        return Err(format!("Failed to pull branch: {}", err).into());
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to pull branch".into());
     }
 
     app.add_log("INFO", format!("Pulled branch: {}", branch_name));
@@ -777,9 +768,8 @@ pub fn git_stash_pop_autostash_if_exists(app: &mut App) -> Result<(), Box<dyn Er
         .output()?;
 
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).to_string();
-        app.add_error(err.clone());
-        return Err(format!("Failed to list stashes: {}", err).into());
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to list stashes".into());
     }
 
     let stash_list = String::from_utf8(output.stdout)?;
@@ -795,9 +785,8 @@ pub fn git_stash_pop_autostash_if_exists(app: &mut App) -> Result<(), Box<dyn Er
                 .output()?;
 
             if !output.status.success() {
-                let err = String::from_utf8_lossy(&output.stderr).to_string();
-                app.add_error(err.clone());
-                return Err(format!("Failed to apply stash: {}", err).into());
+                app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+                return Err("Failed to apply stash".into());
             }
             app.add_log("INFO", format!("Applied {}", AUTOSTASH_NAME));
             return Ok(());
@@ -823,9 +812,8 @@ pub fn git_stage_and_commit(
         if output.status.success() {
             app.add_log("INFO", "Staged all changes");
         } else {
-            let err = String::from_utf8_lossy(&output.stderr).to_string();
-            app.add_error(err.clone());
-            return Err(format!("Failed to stage changes: {}", err).into());
+            app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+            return Err("Failed to stage changes".into());
         }
     }
 
@@ -855,9 +843,8 @@ pub fn git_push_branch(app: &mut App, branch_name: &str) -> Result<(), Box<dyn E
     let output = Command::new("git").args(&push_args).output()?;
 
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).to_string();
-        app.add_error(err.clone());
-        return Err(format!("Failed to push branch: {}", err).into());
+        app.add_error(String::from_utf8_lossy(&output.stderr).to_string());
+        return Err("Failed to push branch".into());
     }
 
     app.add_log("INFO", format!("Pushed branch {} to origin", branch_name));


### PR DESCRIPTION
### Problem (Why?)
The current `git_ops` module duplicates error variable creation, clones stderr strings, and embeds dynamic error content in returned `Err` messages. This adds unnecessary complexity and leads to verbose, inconsistent code.

### Solution (What?)
Refactor all `git_*` operations to inline stderr logging and return concise, static error strings instead of formatted messages containing the stderr payload.

### Details (How?)
- Removed intermediate `err` variables and their `.clone()` calls.
- Inlined `app.add_error(String::from_utf8_lossy(&output.stderr).to_string())` for all failing commands.
- Replaced `Err(format!("Failed to ...: {}", err))` with `Err("Failed to ...".into())` for consistency.
- Applied this pattern uniformly across `git_main_branch`, `git_current_branch`, `git_fetch_main`, `git_checkout_branch`, `git_commit_staged_changes`, `git_pull_branch`, `git_stash_pop_autostash_if_exists`, `git_stage_and_commit`, and `git_push_branch` functions.
