### PR TITLE
Add external diff review gate with autonomous prep and config/CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The GitHub PR Tool is a Rust-based command-line utility designed to streamline t
 
 - **Smart Branch Naming**: Automatically generate descriptive branch names based on the content of your changes.
 - **Commit Message Assistance**: Create concise commit titles and optional detailed descriptions using OpenAI's LLM.
-- **Automated Workflow**: Stage changes, create a branch, commit changes, and open a pull request with minimal effort.
+- **Automated Workflow**: Stage changes, create a branch, commit changes, run optional external review/prep, and open a pull request with minimal effort.
+- **External Diff Review Gate**: Optionally run ACP/opencode/other CLI agents as a diff reviewer before push + PR creation, with support for blocking, user-feedback, autonomous prep loops, and ready-to-submit decisions.
 - **Interactive Staging**: Offers to stage unstaged changes interactively if no changes are staged.
 - **Error Handling**: Validates prerequisites like being inside a Git repository and having the OpenAI API key set.
 
@@ -53,11 +54,39 @@ The GitHub PR Tool is a Rust-based command-line utility designed to streamline t
    - Check for staged changes.
    - If none are staged, interactively ask to stage unstaged changes.
    - Generate a branch name and commit message based on the changes.
-   - Create a new branch, commit changes, and open a pull request.
+   - Optionally run an external reviewer (`--review-command`) on the branch diff and enforce one of: block submission, request user feedback, autonomously prepare/amend, or proceed.
+   - Create/update a pull request only when the review verdict is ready for submission.
+
+### Optional Review Command
+
+Configure `[review]` in `~/.config/gh-autopr/config.toml` to run review automatically every time. Review is enabled by default; set `enabled = false` to disable it. Use `--review-command` to override per-run when review is enabled.
+
+You can invoke any CLI reviewer (for example ACP, `opencode`, or `ralph`) that reads a prompt from stdin and returns strict JSON with a decision.
+
+```bash
+gh-autopr --review-command "opencode run --json" --review-max-rounds 3
+```
+
+
+### User-level config example
+
+```toml
+[review]
+enabled = true
+command = "opencode run --json"
+max_rounds = 3
+```
+
+Supported decisions:
+- `not_worth_submission`: stop and report feedback, no PR submitted
+- `needs_user_feedback`: stop and present reviewer questions, no PR submitted
+- `needs_autonomous_prep`: run provided prep commands, amend commit, then re-review (loop)
+- `ready_for_submission`: continue to push + PR creation
 
 ## Environment Variables
 
 - `OPENAI_KEY`: Your OpenAI API key, required for generating branch names and commit messages.
+- `AUTOPR_REVIEW_ENABLED`: Optional review toggle (`true/false`); defaults to enabled.
 
 ## Example
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,11 +11,18 @@ use std::path::PathBuf;
 /// api_key  = "sk-ant-..."      # API key (prefer env var or keyring over plaintext)
 /// model    = "claude-opus-4-6" # model name; see https://docs.anthropic.com/en/docs/about-claude/models
 /// base_url = "https://..."     # optional custom endpoint
+///
+/// [review]
+/// enabled = true                    # optional: default true; set false to skip review entirely
+/// command = "opencode run --json" # optional: if set and enabled, review runs automatically
+/// max_rounds = 2                    # optional: autonomous prep loop cap
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct AppConfig {
     #[serde(default)]
     pub ai: AiConfig,
+    #[serde(default)]
+    pub review: ReviewConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -28,6 +35,31 @@ pub struct AiConfig {
     pub model: Option<String>,
     /// Optional custom base URL (e.g. for local proxies or compatible endpoints)
     pub base_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReviewConfig {
+    /// Whether review is enabled. Defaults to true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// External review command (reads prompt from stdin, outputs strict JSON)
+    pub command: Option<String>,
+    /// Max autonomous prep rounds before giving up
+    pub max_rounds: Option<u32>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for ReviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            command: None,
+            max_rounds: None,
+        }
+    }
 }
 
 const STUB: &str = r#"# gh-autopr configuration — edit this file, then re-run gh-autopr.
@@ -51,6 +83,20 @@ model = "claude-opus-4-6"
 # api_key  = ""        # or set OPENAI_KEY in your environment
 # model    = "gpt-4o-mini"
 # base_url = "https://api.openai.com/v1"  # optional
+
+[review]
+# Review is enabled by default. Set to false to skip review entirely.
+enabled = true
+
+# Optional: if set, diff review runs automatically before PR creation.
+# Works with ACP/opencode/ralph CLI/any agent that reads stdin and outputs strict JSON.
+# command = "opencode run --json"
+
+# Optional autonomous prep loop cap.
+# max_rounds = 2
+
+# If you prefer the ralph CLI, put your command wrapper here, e.g.:
+# command = "ralph run --json"
 "#;
 
 impl AppConfig {
@@ -115,6 +161,9 @@ impl AppConfig {
     /// - API key:   `AUTOPR_API_KEY` > provider-specific fallback
     /// - Model:     `AUTOPR_MODEL` > provider-specific fallback
     /// - Base URL:  `AUTOPR_BASE_URL` > provider-specific fallback
+    /// - Review enabled: `AUTOPR_REVIEW_ENABLED`
+    /// - Review cmd: `AUTOPR_REVIEW_COMMAND`
+    /// - Review rounds: `AUTOPR_REVIEW_MAX_ROUNDS`
     ///
     /// Provider-specific fallbacks:
     /// - anthropic: `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`, `ANTHROPIC_BASE_URL`
@@ -161,6 +210,21 @@ impl AppConfig {
                 self.ai.base_url = Some(u);
             }
         }
+
+        if let Ok(v) = std::env::var("AUTOPR_REVIEW_ENABLED") {
+            let normalized = v.trim().to_ascii_lowercase();
+            self.review.enabled = matches!(normalized.as_str(), "1" | "true" | "yes" | "on");
+        }
+
+        if let Ok(v) = std::env::var("AUTOPR_REVIEW_COMMAND") {
+            self.review.command = Some(v);
+        }
+
+        if let Ok(v) = std::env::var("AUTOPR_REVIEW_MAX_ROUNDS") {
+            if let Ok(parsed) = v.parse::<u32>() {
+                self.review.max_rounds = Some(parsed.max(1));
+            }
+        }
     }
 
     /// Effective provider (defaults to "openai").
@@ -179,5 +243,52 @@ impl AppConfig {
                 "anthropic" => "claude-opus-4-6",
                 _ => "gpt-4o-mini",
             })
+    }
+
+    pub fn review_enabled(&self) -> bool {
+        self.review.enabled
+    }
+
+    pub fn review_command(&self) -> Option<&str> {
+        self.review.command.as_deref().and_then(|v| {
+            if self.review_enabled() && !v.trim().is_empty() {
+                Some(v)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn review_max_rounds(&self) -> u32 {
+        self.review.max_rounds.unwrap_or(2).max(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_defaults_are_stable() {
+        let cfg = AppConfig::default();
+        assert!(cfg.review_enabled());
+        assert!(cfg.review_command().is_none());
+        assert_eq!(cfg.review_max_rounds(), 2);
+    }
+
+    #[test]
+    fn review_command_trims_empty_values() {
+        let mut cfg = AppConfig::default();
+        cfg.review.command = Some("   ".to_string());
+        assert!(cfg.review_command().is_none());
+    }
+
+    #[test]
+    fn review_command_respects_enabled_flag() {
+        let mut cfg = AppConfig::default();
+        cfg.review.command = Some("opencode run --json".to_string());
+        cfg.review.enabled = false;
+        assert!(!cfg.review_enabled());
+        assert!(cfg.review_command().is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod git_ops;
 pub mod git_temp_worktree;
 pub mod github_ops;
 pub mod gpt_ops;
+pub mod review_ops;
 pub mod tui;
 
 // Re-export commonly used items
@@ -11,4 +12,5 @@ pub use git_ops::*;
 pub use git_temp_worktree::*;
 pub use github_ops::*;
 pub use gpt_ops::*;
+pub use review_ops::*;
 pub use tui::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,14 @@ mod git_ops;
 mod git_temp_worktree;
 mod github_ops;
 mod gpt_ops;
+mod review_ops;
 mod tui;
 use crate::config::AppConfig;
 use crate::git_ops::*;
 use crate::git_temp_worktree::*;
 use crate::github_ops::*;
 use crate::gpt_ops::*;
+use crate::review_ops::*;
 use crate::tui::*;
 use clap::Parser;
 use ratatui::{
@@ -57,6 +59,14 @@ struct Args {
     /// Prune local branches that have been merged
     #[arg(long, visible_aliases = ["prune", "cleanup"])]
     prune_branches: bool,
+
+    /// External command used for diff review; receives review prompt on stdin and must output JSON
+    #[arg(long)]
+    review_command: Option<String>,
+
+    /// Maximum autonomous review/prep rounds when external reviewer requests additional prep
+    #[arg(long, default_value_t = 2)]
+    review_max_rounds: u32,
 }
 
 /// Configuration passed from CLI args to the run function
@@ -67,6 +77,8 @@ struct RunConfig {
     what: Option<String>,
     why: Option<String>,
     bigger_picture: Option<String>,
+    review_command: Option<String>,
+    review_max_rounds: u32,
 }
 
 /// Branch information gathered before entering temp worktree
@@ -111,6 +123,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         what: args.what,
         why: args.why,
         bigger_picture: args.bigger_picture,
+        review_command: args.review_command,
+        review_max_rounds: args.review_max_rounds,
     };
 
     // Do git operations that need original worktree BEFORE entering temp worktree
@@ -339,15 +353,95 @@ where
         return Ok(());
     }
 
+    // External diff review + prep gate before any push/PR creation
+    // CLI flags override user-level config; config values run automatically when set.
+    let review_enabled = app_config.review_enabled();
+    let effective_review_command = if review_enabled {
+        config
+            .review_command
+            .clone()
+            .or_else(|| app_config.review_command().map(ToString::to_string))
+    } else {
+        app.add_log(
+            "INFO",
+            "Review disabled in user config; skipping external review.",
+        );
+        None
+    };
+    let effective_review_max_rounds = if config.review_command.is_some() {
+        config.review_max_rounds
+    } else {
+        app_config.review_max_rounds()
+    };
+
+    let review_result = review_and_prepare_change(
+        app,
+        &ExternalReviewConfig {
+            review_command: effective_review_command,
+            max_rounds: effective_review_max_rounds,
+        },
+        &base_branch,
+        &current_branch,
+        diff_between_branches.clone(),
+    )?;
+
+    app.add_log("INFO", format!("Review verdict: {}", review_result.summary));
+    for item in &review_result.feedback {
+        app.add_log("INFO", format!("Review feedback: {}", item));
+    }
+    refresh_ui(terminal, app, tick_rate, &mut last_tick)?;
+
+    match review_result.decision {
+        ReviewDecision::NotWorthSubmission => {
+            app.add_log(
+                "INFO",
+                "Review blocked PR submission as not worth submitting.",
+            );
+            app.update_progress(1.0);
+            refresh_ui(terminal, app, tick_rate, &mut last_tick)?;
+            run_event_loop(terminal, app, tick_rate, &mut last_tick)?;
+            return Ok(());
+        }
+        ReviewDecision::NeedsUserFeedback => {
+            app.add_log("INFO", "Review requires user feedback before submission.");
+            app.add_log(
+                "INFO",
+                "Interactive question answering is not supported in this TUI flow yet; re-run with answers/context.",
+            );
+            for q in &review_result.questions {
+                app.add_log("INFO", format!("Question: {}", q));
+            }
+            app.update_progress(1.0);
+            refresh_ui(terminal, app, tick_rate, &mut last_tick)?;
+            run_event_loop(terminal, app, tick_rate, &mut last_tick)?;
+            return Ok(());
+        }
+        ReviewDecision::NeedsAutonomousPrep => {
+            return Err(
+                "Unexpected review state: autonomous prep should have converged"
+                    .to_string()
+                    .into(),
+            );
+        }
+        ReviewDecision::ReadyForSubmission => {
+            app.add_log("INFO", "Review marked change as ready for submission.");
+        }
+    }
+
+    // Re-read final diff in case autonomous prep amended the commit.
+    let final_diff_between_branches =
+        git_diff_between_branches(app, &base_branch, &current_branch)?;
+    refresh_ui(terminal, app, tick_rate, &mut last_tick)?;
+
     // Get PR title/body (reuse cached or generate new)
     let (pr_title, pr_body) = match cached_gpt_response {
-        Some((title, details)) => {
+        Some((title, details)) if final_diff_between_branches == diff_between_branches => {
             app.add_log("INFO", "Reusing generated content for PR...");
             app.update_progress(0.5);
             refresh_ui(terminal, app, tick_rate, &mut last_tick)?;
             (title, details)
         }
-        None => {
+        _ => {
             app.add_log("INFO", "Generating PR details...");
             app.update_progress(0.5);
             refresh_ui(terminal, app, tick_rate, &mut last_tick)?;
@@ -355,7 +449,7 @@ where
             let (_, title, details) = gpt_generate_branch_name_and_commit_description(
                 app,
                 &app_config,
-                diff_between_branches,
+                final_diff_between_branches,
                 Some(issues_json),
                 config.what,
                 config.why,

--- a/src/review_ops.rs
+++ b/src/review_ops.rs
@@ -1,0 +1,229 @@
+use crate::tui::App;
+use serde::Deserialize;
+use std::process::{Command, Stdio};
+
+#[derive(Debug, Clone)]
+pub struct ExternalReviewConfig {
+    pub review_command: Option<String>,
+    pub max_rounds: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewDecision {
+    NotWorthSubmission,
+    NeedsUserFeedback,
+    NeedsAutonomousPrep,
+    ReadyForSubmission,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReviewResult {
+    pub decision: ReviewDecision,
+    pub summary: String,
+    pub feedback: Vec<String>,
+    pub questions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewResponse {
+    decision: String,
+    summary: Option<String>,
+    feedback: Option<Vec<String>>,
+    questions: Option<Vec<String>>,
+    prep_commands: Option<Vec<String>>,
+}
+
+pub fn review_and_prepare_change(
+    app: &mut App<'_>,
+    config: &ExternalReviewConfig,
+    base_branch: &str,
+    current_branch: &str,
+    initial_diff: String,
+) -> Result<ReviewResult, Box<dyn std::error::Error>> {
+    let Some(review_command) = config.review_command.as_deref() else {
+        app.add_log(
+            "INFO",
+            "No review command configured; skipping external diff review.",
+        );
+        return Ok(ReviewResult {
+            decision: ReviewDecision::ReadyForSubmission,
+            summary: "Review skipped (no command configured).".to_string(),
+            feedback: vec![],
+            questions: vec![],
+        });
+    };
+
+    let mut diff = initial_diff;
+
+    for round in 1..=config.max_rounds.max(1) {
+        app.add_log(
+            "INFO",
+            format!("External review round {}/{}", round, config.max_rounds),
+        );
+
+        let response = run_reviewer(review_command, base_branch, current_branch, &diff)?;
+        let summary = response
+            .summary
+            .unwrap_or_else(|| "No summary provided.".to_string());
+        let feedback = response.feedback.unwrap_or_default();
+        let questions = response.questions.unwrap_or_default();
+
+        let decision = parse_decision(&response.decision)?;
+        let prep_commands = response.prep_commands.unwrap_or_default();
+
+        match decision {
+            ReviewDecision::NotWorthSubmission => {
+                return Ok(ReviewResult {
+                    decision,
+                    summary,
+                    feedback,
+                    questions,
+                });
+            }
+            ReviewDecision::NeedsUserFeedback => {
+                return Ok(ReviewResult {
+                    decision,
+                    summary,
+                    feedback,
+                    questions,
+                });
+            }
+            ReviewDecision::ReadyForSubmission => {
+                return Ok(ReviewResult {
+                    decision,
+                    summary,
+                    feedback,
+                    questions,
+                });
+            }
+            ReviewDecision::NeedsAutonomousPrep => {
+                if !questions.is_empty() {
+                    return Ok(ReviewResult {
+                        decision: ReviewDecision::NeedsUserFeedback,
+                        summary,
+                        feedback,
+                        questions,
+                    });
+                }
+
+                if prep_commands.is_empty() {
+                    return Err(
+                        "Reviewer requested autonomous prep but returned no prep_commands"
+                            .to_string()
+                            .into(),
+                    );
+                }
+
+                for prep in prep_commands {
+                    app.add_log("INFO", format!("Running prep command: {}", prep));
+                    run_shell_command(&prep)?;
+                }
+
+                let status = Command::new("git")
+                    .args(["status", "--porcelain"])
+                    .output()?;
+                if !status.status.success() {
+                    return Err("Failed to inspect git status after prep".to_string().into());
+                }
+
+                if !String::from_utf8_lossy(&status.stdout).trim().is_empty() {
+                    run_shell_command("git add -A")?;
+                    run_shell_command("git commit --amend --no-edit")?;
+                    app.add_log("INFO", "Amended commit with autonomous prep updates.");
+                } else {
+                    app.add_log("INFO", "Autonomous prep made no file changes.");
+                }
+
+                let output = Command::new("git")
+                    .args(["diff", "--", &format!("{base_branch}...{current_branch}")])
+                    .output()?;
+                if !output.status.success() {
+                    return Err("Failed to re-read branch diff after prep"
+                        .to_string()
+                        .into());
+                }
+                diff = String::from_utf8_lossy(&output.stdout).to_string();
+            }
+        }
+    }
+
+    Err(
+        "Review did not converge to ready/blocking state within max review rounds"
+            .to_string()
+            .into(),
+    )
+}
+
+fn parse_decision(raw: &str) -> Result<ReviewDecision, Box<dyn std::error::Error>> {
+    match raw.trim() {
+        "not_worth_submission" => Ok(ReviewDecision::NotWorthSubmission),
+        "needs_user_feedback" => Ok(ReviewDecision::NeedsUserFeedback),
+        "needs_autonomous_prep" => Ok(ReviewDecision::NeedsAutonomousPrep),
+        "ready_for_submission" => Ok(ReviewDecision::ReadyForSubmission),
+        other => Err(format!("Unknown review decision: {}", other).into()),
+    }
+}
+
+fn run_reviewer(
+    command: &str,
+    base_branch: &str,
+    current_branch: &str,
+    diff: &str,
+) -> Result<ReviewResponse, Box<dyn std::error::Error>> {
+    let prompt = format!(
+        "You are reviewing a git diff before PR submission.\\nBase branch: {}\\nCurrent branch: {}\\n\\nReturn ONLY strict JSON with this schema:\\n{{\\n  \"decision\": \"not_worth_submission\" | \"needs_user_feedback\" | \"needs_autonomous_prep\" | \"ready_for_submission\",\\n  \"summary\": string,\\n  \"feedback\": string[],\\n  \"questions\": string[],\\n  \"prep_commands\": string[]\\n}}\\n\\nRules:\\n- Use not_worth_submission if this change should not be submitted as a PR.\\n- Use needs_user_feedback if submission could be worth it but user clarification is required.\\n- Use needs_autonomous_prep when no user input is needed but local prep should happen before PR submission.\\n- Use ready_for_submission if PR can be created now.\\n- If decision is needs_user_feedback, put user-facing questions in questions.\\n- If decision is needs_autonomous_prep, include shell prep_commands to run from repo root and keep questions empty.\\n\\nDiff:\\n{}",
+        base_branch, current_branch, diff
+    );
+
+    let mut child = Command::new("bash")
+        .arg("-lc")
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    use std::io::Write;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(prompt.as_bytes())?;
+    }
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Review command failed: {}", stderr).into());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: ReviewResponse = serde_json::from_str(stdout.trim()).map_err(|e| {
+        format!(
+            "Review command did not return valid JSON: {}. Output: {}",
+            e, stdout
+        )
+    })?;
+
+    Ok(parsed)
+}
+
+fn run_shell_command(cmd: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("bash").arg("-lc").arg(cmd).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Command failed `{}`: {}", cmd, stderr).into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_decisions() {
+        assert_eq!(
+            parse_decision("ready_for_submission").unwrap(),
+            ReviewDecision::ReadyForSubmission
+        );
+        assert!(parse_decision("bogus").is_err());
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce an optional external diff review step to allow CLI reviewers (e.g., ACP/opencode/ralph) to block, request user feedback, or drive autonomous local prep before pushing and creating a PR.
- Expose user-level config and CLI overrides so review behavior can be enabled/disabled and customized per-run. 

### Description

- Add `ReviewConfig` to `AppConfig` with `enabled`, `command`, and `max_rounds`, environment overrides (`AUTOPR_REVIEW_*`), and helper accessors `review_enabled()`, `review_command()`, and `review_max_rounds()` in `src/config.rs`.
- Add CLI flags `--review-command` and `--review-max-rounds` to `Args` and propagate them via `RunConfig` in `src/main.rs` to override user config for a run.
- Implement `review_ops` module (`src/review_ops.rs`) that runs an external review command, parses strict JSON responses, supports decisions `not_worth_submission`, `needs_user_feedback`, `needs_autonomous_prep`, and `ready_for_submission`, and performs autonomous prep commands (run, `git add -A`, `git commit --amend --no-edit`) in a loop up to `max_rounds`.
- Integrate the review gate into the main flow before any push/PR creation, log review feedback to the TUI, re-read the diff after prep, and only proceed when the review marks the change `ready_for_submission` or otherwise stop with appropriate messages.
- Update `README.md` with documentation and examples for the optional review command and a sample `~/.config/gh-autopr/config.toml` section, and re-export `review_ops` in `lib.rs`.

### Testing

- Ran unit tests with `cargo test`; `src/config.rs` tests verifying review defaults and command trimming (`review_defaults_are_stable`, `review_command_trims_empty_values`, `review_command_respects_enabled_flag`) passed.
- Ran `src/review_ops.rs` unit test (`parse_decisions`) which passed and verifies decision parsing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33ecdfb1c8320aa026634de6252e3)